### PR TITLE
Fix for surface render not unloading

### DIFF
--- a/libraries/surface render/surface render.lua
+++ b/libraries/surface render/surface render.lua
@@ -544,6 +544,7 @@ local painttraverse = function (void, int, bool, bool2)
         for _, render in pairs(renderer.funcs) do
             render()
         end
+        renderer.funcs = {}
     end
     VGUI_Panel(void, int, bool, bool2)
 end


### PR DESCRIPTION
If the surface render library is used in a loop, it will result in many of the same things appearing and then not being updated with the callbacks
So to avoid this problem, I think it would be better to clear the table after execution
( I hope you don't mind that I used a machine translation because my English is very poor :) )